### PR TITLE
Add cache control header for getAudioFileHandler

### DIFF
--- a/backend/cmd/api/handlers.go
+++ b/backend/cmd/api/handlers.go
@@ -124,6 +124,7 @@ func (app *application) getAudioFileHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	w.Header().Set("Cache-Control", "no-cache")
 	http.ServeContent(w, r, info.Name(), info.ModTime(), file)
 }
 


### PR DESCRIPTION
Add `Cache-Control: no-cache` to the `getAudioFileHandler` to make sure all clients use the headers provided by `http.ServeContent` consistently. The resulting behavior is that the server will return a `304 Not Modified` when the client already has the same version of the file as the one that is on the server. If not the new version will be fetched.

A the moment no cache header is set so the resulting behavior is heavily dependent on the client and any (reverse) proxies in between. Traefik for example wont cache anything currently.